### PR TITLE
Implements a new configuration setting to ignore ASNs received from flow data

### DIFF
--- a/console/data/docs/02-configuration.md
+++ b/console/data/docs/02-configuration.md
@@ -143,6 +143,9 @@ The following configuration keys are accepted:
   classifiers are pure, their result is cached in a cache. The metrics
   should tell if the cache is big enough. It should be set at least to
   twice the number of the most busy interfaces.
+- `ignore-asn-from-flow` allows to ignore the AS numbers of the source and
+  destination IP from the received flows. It can be useful for routers with a
+  partial routing table and a default route learned over BGP.
 
 Classifier rules are written using [expr][].
 

--- a/inlet/core/config.go
+++ b/inlet/core/config.go
@@ -13,6 +13,8 @@ type Configuration struct {
 	InterfaceClassifiers []InterfaceClassifierRule
 	// ClassifierCacheSize defines the size of the classifier (in number of items)
 	ClassifierCacheSize uint
+	// Ignore source/dest AS numbers from received flows
+	IgnoreASNFromFlow bool
 }
 
 // DefaultConfiguration represents the default configuration for the core component.
@@ -22,5 +24,6 @@ func DefaultConfiguration() Configuration {
 		ExporterClassifiers:  []ExporterClassifierRule{},
 		InterfaceClassifiers: []InterfaceClassifierRule{},
 		ClassifierCacheSize:  1000,
+		IgnoreASNFromFlow:    false,
 	}
 }

--- a/inlet/core/hydrate.go
+++ b/inlet/core/hydrate.go
@@ -75,10 +75,10 @@ func (c *Component) hydrateFlow(exporter string, flow *flow.Message) (skip bool)
 		&flow.InIfConnectivity, &flow.InIfProvider, &flow.InIfBoundary)
 
 	// Add GeoIP
-	if flow.SrcAS == 0 {
+	if flow.SrcAS == 0 || c.config.IgnoreASNFromFlow {
 		flow.SrcAS = c.d.GeoIP.LookupASN(net.IP(flow.SrcAddr))
 	}
-	if flow.DstAS == 0 {
+	if flow.DstAS == 0 || c.config.IgnoreASNFromFlow {
 		flow.DstAS = c.d.GeoIP.LookupASN(net.IP(flow.DstAddr))
 	}
 	flow.SrcCountry = c.d.GeoIP.LookupCountry(net.IP(flow.SrcAddr))


### PR DESCRIPTION
This new setting allows to ignore source and destination autonomous system numbers received from flow data and rely solely on MaxMind's data.

This is useful when an exporter only gets a partial routing table as well a default route from a transit provider. Without it all flows matched against the default route on the exporter have the transit provider's AS number instead of the origin's.

However, as I am not familiar with Akvorado's code, it might not be the best way to implements this and it might be interesting to have this setting available per exporter rather than globally.