### PR TITLE
Convert InIfBoundary/OutIfBoundary from Enum8 to String to use as a dimension

### DIFF
--- a/console/query.go
+++ b/console/query.go
@@ -132,7 +132,7 @@ func (gc queryColumn) toSQLSelect() string {
 			helpers.ETypeIPv4, helpers.ETypeIPv6)
 	case queryColumnProto:
 		strValue = `dictGetOrDefault('protocols', 'name', Proto, '???')`
-	case queryColumnInIfSpeed, queryColumnOutIfSpeed, queryColumnSrcPort, queryColumnDstPort, queryColumnForwardingStatus:
+	case queryColumnInIfSpeed, queryColumnOutIfSpeed, queryColumnSrcPort, queryColumnDstPort, queryColumnForwardingStatus, queryColumnInIfBoundary, queryColumnOutIfBoundary:
 		strValue = fmt.Sprintf("toString(%s)", gc)
 	default:
 		strValue = gc.String()


### PR DESCRIPTION
Using InIfBoundary and/or OutIfBoundary as dimensions yields the following error:

```
{"level":"error","error":"code: 386, message: There is no supertype for types Enum8('undefined' = 0, 'external' = 1, 'internal' = 2), String because some of them are String/FixedString and some of them are not: While processing if(InIfBoundary IN (rows AS _subquery300), [InIfBoundary], ['Other']) AS dimensions","time":"2022-07-16T08:40:34Z","caller":"akvorado/console/graph.go:139","module":"akvorado/console","message":"unable to query database"}
```

This change converts Enum numeric values to their string representation to allow the use of InIfBoundary and/or OutIfBoundary as dimensions.