### PR TITLE
console: add `<<`/`!<<` operator to subnet match for SrcAddr/DstAddr

### DIFF
--- a/console/data/docs/03-usage.md
+++ b/console/data/docs/03-usage.md
@@ -154,7 +154,7 @@ guaranteed, so an URL may stop working after a few upgrades.
 The filter language looks like SQL with a few variations. Fields
 listed as dimensions can usually be used. Accepted operators are `=`,
 `!=`, `<`, `<=`, `>`, `>=`, `IN`, `NOTIN`, `LIKE`, `UNLIKE`, `ILIKE`,
-`IUNLIKE`, when they make sense. Here are a few examples:
+`IUNLIKE`, `<<`, `!<<` when they make sense. Here are a few examples:
 
 - `InIfBoundary = external` only selects flows whose incoming
   interface was classified as external. The value should not be
@@ -165,6 +165,8 @@ listed as dimensions can usually be used. Accepted operators are `=`,
   limits the source AS number of selected flows.
 - `SrcAddr = 203.0.113.4` only selects flows with the specified
   address. Note that filtering on IP addresses is usually slower.
+- `SrcAddr << 203.0.113.0/24` only selects flows matching the
+  specified subnet.
 - `ExporterName LIKE th2-%` selects flows coming from routers
   starting with `th2-`.
 

--- a/console/data/docs/99-changelog.md
+++ b/console/data/docs/99-changelog.md
@@ -13,8 +13,11 @@ identified with a specific icon:
 
 ## Unreleased
 
+- ✨ *console*: add `<<`/`!<<` operator for `SrcAddr` and `DstAddr` to match on a subnet [PR #57][]
 - 🩹 *build*: remove `-dirty` from version number in released Docker images
 - 🌱 *console*: hide `::ffff:` prefix from IPv6-mapped IPv4 addresses
+
+[PR #57]: https://github.com/vincentbernat/akvorado/pull/47
 
 ## 1.5.1 - 2022-07-22
 

--- a/console/filter/parser.peg
+++ b/console/filter/parser.peg
@@ -54,6 +54,7 @@ NotExpr "NOT expression" ← KW_NOT _ expr:Expr {
 
 ConditionExpr "conditional" ←
     ConditionIPExpr
+  / ConditionExporterAddrExpr
   / ConditionStringExpr
   / ConditionBoundaryExpr
   / ConditionSpeedExpr
@@ -64,11 +65,26 @@ ConditionExpr "conditional" ←
   / ConditionProtoExpr
   / ConditionPacketSizeExpr
 
+ColumnIP ←
+   "SrcAddr"i { return "SrcAddr", nil }
+ / "DstAddr"i { return "DstAddr", nil }
 ConditionIPExpr "condition on IP" ←
- column:("ExporterAddress"i { return "ExporterAddress", nil }
-      / "SrcAddr"i { return "SrcAddr", nil }
-      / "DstAddr"i { return "DstAddr", nil }) _ operator:("=" / "!=") _ ip:IP {
-  return fmt.Sprintf("%s %s IPv6StringToNum(%s)", toString(column), toString(operator), quote(ip)), nil
+   column:ColumnIP _
+   operator:("=" / "!=") _ ip:IP {
+     return fmt.Sprintf("%s %s IPv6StringToNum(%s)", toString(column), toString(operator), quote(ip)), nil
+   }
+ / column:ColumnIP _
+   operator:"<<" _ subnet:Subnet {
+     return fmt.Sprintf("isIPAddressInRange(toString(%s), %s)", toString(column), quote(subnet)), nil
+   }
+ / column:ColumnIP _
+   operator:"!<<" _ subnet:Subnet {
+     return fmt.Sprintf("NOT isIPAddressInRange(toString(%s), %s)", toString(column), quote(subnet)), nil
+   }
+
+ConditionExporterAddrExpr "condition on ExporterAddr" ←
+ "ExporterAddress"i _ operator:("=" / "!=") _ ip:IP {
+  return fmt.Sprintf("ExporterAddress %s IPv6StringToNum(%s)", toString(operator), quote(ip)), nil
 }
 
 ConditionStringExpr "condition on string" ←
@@ -181,6 +197,18 @@ IP "IP address" ← [0-9A-Fa-f:.]+ !IdentStart {
     return false, fmt.Errorf("expecting an IP address")
   }
   return ip.String(), nil
+}
+
+Subnet "IP subnet" ← [0-9A-Fa-f:.]+ "/" [0-9]+ !IdentStart {
+  _, net, err := net.ParseCIDR(string(c.text))
+  if err != nil {
+    return false, fmt.Errorf("expecting a subnet")
+  }
+  if net.IP.To4() == nil {
+    return net.String(), nil
+  }
+  plen, _ := net.Mask.Size()
+  return fmt.Sprintf("::ffff:%s/%d", net.IP.String(), plen + 96), nil
 }
 
 ASN "AS number" ← "AS"i? value:Unsigned32 {

--- a/console/filter/parser_test.go
+++ b/console/filter/parser_test.go
@@ -31,6 +31,10 @@ func TestValidFilter(t *testing.T) {
 		{`ExporterAddress=203.0.113.1`, `ExporterAddress = IPv6StringToNum('203.0.113.1')`},
 		{`ExporterAddress=2001:db8::1`, `ExporterAddress = IPv6StringToNum('2001:db8::1')`},
 		{`ExporterAddress=2001:db8:0::1`, `ExporterAddress = IPv6StringToNum('2001:db8::1')`},
+		{`SrcAddr << 2001:db8:0::/64`, `isIPAddressInRange(toString(SrcAddr), '2001:db8::/64')`},
+		{`DstAddr << 192.168.0.0/24`, `isIPAddressInRange(toString(DstAddr), '::ffff:192.168.0.0/120')`},
+		{`SrcAddr << 192.168.0.1/24`, `isIPAddressInRange(toString(SrcAddr), '::ffff:192.168.0.0/120')`},
+		{`DstAddr !<< 192.168.0.0/24`, `NOT isIPAddressInRange(toString(DstAddr), '::ffff:192.168.0.0/120')`},
 		{`ExporterGroup= "group"`, `ExporterGroup = 'group'`},
 		{`SrcAddr=203.0.113.1`, `SrcAddr = IPv6StringToNum('203.0.113.1')`},
 		{`DstAddr=203.0.113.2`, `DstAddr = IPv6StringToNum('203.0.113.2')`},
@@ -141,6 +145,9 @@ func TestInvalidFilter(t *testing.T) {
 		{`SrcAS IN (AS12322, 29447`},
 		{`SrcAS IN (AS12322 29447)`},
 		{`SrcAS IN (AS12322,`},
+		// Not yet supported
+		{`ExporterAddress << 2001:db8:0::/64`},
+		{`ExporterAddress << 192.168.0.0/24`},
 	}
 	for _, tc := range cases {
 		out, err := Parse("", []byte(tc.Input))

--- a/console/frontend/src/codemirror/lang-filter/syntax.grammar
+++ b/console/frontend/src/codemirror/lang-filter/syntax.grammar
@@ -37,7 +37,7 @@ ListOfValues {
     '"' (![\\\n"] | "\\" _)* '"'? |
     "'" (![\\\n'] | "\\" _)* "'"?
   }
-  Literal { (std.digit | std.asciiLetter | $[.:])+ }
+  Literal { (std.digit | std.asciiLetter | $[.:/])+ }
   ValueLParen { "(" }
   ValueRParen { ")" }
   ValueComma { "," }
@@ -47,4 +47,5 @@ ListOfValues {
   Not { "not" | "NOT" | "Not" | "NOt" | "NoT" | "nOT" | "nOt" | "noT" }
 
   @precedence { Not, Column }
+  @precedence { Literal, BlockComment }
 }


### PR DESCRIPTION
This does not work for ExporterAddress due to a potential bug in
Clickhouse's isIPAddressInRange when using a LowCardinality type. See
https://github.com/ClickHouse/ClickHouse/issues/39599.