### PR TITLE
orchestrator/clickhouse: fix ORDER BY for summing merge trees

### DIFF
--- a/orchestrator/clickhouse/migrations.go
+++ b/orchestrator/clickhouse/migrations.go
@@ -81,6 +81,9 @@ func (c *Component) migrateDatabase() error {
 				fmt.Sprintf("add Exporter* to flows table with resolution %s", resolution.Interval),
 				c.migrationStepAddExporterColumns(resolution),
 			}, {
+				fmt.Sprintf("fix ORDER BY for flows table with resolution %s", resolution.Interval),
+				c.migrationStepFixOrderByFlowsTable(resolution),
+			}, {
 				fmt.Sprintf("create flows table consumer with resolution %s", resolution.Interval),
 				c.migrationsStepCreateFlowsConsumerTable(resolution),
 			}, {


### PR DESCRIPTION
SrcCountry and DstCountry are missing from the ORDER BY clause of the
summing merge trees. Therefore, they are merged with a random value.
We try to fix that.

However, it is not possible to modify ORDER BY for existing columns.
We get the following error:

```
code: 36, message: Existing column SrcNetName is used in the
expression that was added to the sorting key. You can add expressions
that use only the newly added columns
```